### PR TITLE
Deb packaging cleanups

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export DEPS_DEB="fakeroot make ca-certificates less git vim devscripts debhelper \
+export DEPS_DEB="fakeroot make ca-certificates less vim devscripts debhelper \
   dpkg-dev cmake libevent-dev libglib2.0-dev libpcre3-dev \
   libssl-dev libcurl4-openssl-dev libsqlite3-dev perl \
   libmagic-dev git ragel libicu-dev curl"

--- a/rspamd_build.sh
+++ b/rspamd_build.sh
@@ -637,8 +637,6 @@ build_rspamd_deb() {
     chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed ${RULES_SED} < rspamd-${RSPAMD_VER}/debian/rules > /tmp/.tt ; \
       mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/rules"
   fi
-  chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed ${RULES_SED} < rspamd-${RSPAMD_VER}/debian/rules > /tmp/.tt ; \
-    mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/rules"
   chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed -e 's/native/quilt/' < rspamd-${RSPAMD_VER}/debian/source/format > /tmp/.tt ; \
     mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/source/format"
   rm -f ${HOME}/$d/build.stamp

--- a/rspamd_build.sh
+++ b/rspamd_build.sh
@@ -454,6 +454,7 @@ if [ $DEPS_STAGE -eq 1 ] ; then
 
 
       case $d in
+        debian-wheezy) REAL_DEPS="$DEPS_DEB liblua5.1-dev libgd2-noxpm-dev libunwind7-dev" ;;
         debian-jessie) 
           SPECIFIC_C_COMPILER="clang-8"
           SPECIFIC_CXX_COMPILER="clang++-8"
@@ -466,20 +467,25 @@ if [ $DEPS_STAGE -eq 1 ] ; then
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
           ;;
-        debian-sid) 
-          SPECIFIC_C_COMPILER="clang-9"
-          SPECIFIC_CXX_COMPILER="clang++-9"
-          REAL_DEPS="$DEPS_DEB dh-systemd build-essential ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
-          HYPERSCAN="yes"
-          ;;
         debian-buster)
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
           REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
           HYPERSCAN="yes"
           ;;
-        debian-wheezy) REAL_DEPS="$DEPS_DEB liblua5.1-dev libgd2-noxpm-dev libunwind7-dev" ;;
+        debian-sid) 
+          SPECIFIC_C_COMPILER="clang-9"
+          SPECIFIC_CXX_COMPILER="clang++-9"
+          REAL_DEPS="$DEPS_DEB dh-systemd build-essential ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
+          HYPERSCAN="yes"
+          ;;
         ubuntu-precise) REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP} libgd2-noxpm-dev libunwind8-dev" ;;
+        ubuntu-trusty)
+          SPECIFIC_C_COMPILER="clang-6.0"
+          SPECIFIC_CXX_COMPILER="clang++-6.0"
+          REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP} libgd-dev libopenblas-dev liblapack-dev libunwind8-dev"
+          HYPERSCAN="yes"
+          ;;
         ubuntu-xenial) 
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
@@ -490,12 +496,6 @@ if [ $DEPS_STAGE -eq 1 ] ; then
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
           REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
-          HYPERSCAN="yes"
-          ;;
-        ubuntu-trusty)
-          SPECIFIC_C_COMPILER="clang-6.0"
-          SPECIFIC_CXX_COMPILER="clang++-6.0"
-          REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP} libgd-dev libopenblas-dev liblapack-dev libunwind8-dev"
           HYPERSCAN="yes"
           ;;
         ubuntu-*)

--- a/rspamd_build.sh
+++ b/rspamd_build.sh
@@ -295,7 +295,8 @@ dep_deb() {
         if [ $? -ne 0 ] ; then
           exit 1
         fi
-        curl 'ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.41.tar.gz' > ${HOME}/$d/pcre-8.41.tar.gz
+        curl -sLo ${HOME}/$d/pcre-8.41.tar.gz https://ftp.pcre.org/pub/pcre/pcre-8.41.tar.gz
+        ( cd ${HOME}/$d; sha256sum -c <<<"244838e1f1d14f7e2fa7681b857b3a8566b74215f28133f14a8f5e59241b682c  pcre-8.41.tar.gz" ) || exit 1
         echo "add_subdirectory(chimera)" >> ${HOME}/$d/hyperscan/CMakeLists.txt
         ( cd ${HOME}/$d/hyperscan/ ; tar xzf ${HOME}/$d/pcre-8.41.tar.gz )
         chroot ${HOME}/$d "sed" -i -e 's/CMAKE_POLICY/#CMAKE_POLICY/' hyperscan/pcre-8.41/CMakeLists.txt  


### PR DESCRIPTION
Some cleanups for packaging.

Changes:
* Remove duplicate git package in DEPS_DEB
* Sort build config by distro release (no functional change)
* Verify pcre integrity before use
* Remove duplicate sed invocation (see previous lines)

There are still some cases where the integrity is not verified, but the worst (plaintext ftp) is fixed. The cases are:
- `${HOME}/boost.tar.gz` is assumed to be present. Presumably unmodified boost 1.59.0 sources following https://intel.github.io/hyperscan/dev-reference/getting_started.html#boost-headers
  - For Debian Stretch and newer, you can also use `libboost-dev`. Only Debian Jessie is too old (1.55.0.2).
- hyperscan is cloned from git instead of being built from a stable release/commit.
  - For Debian Stretch(-backports)/Buster and newer you can consider using the bundled hyperscan. See https://packages.debian.org/search?keywords=hyperscan for availability.
- luajit is cloned from the v2.1 branch instead of a fixed commit.
  - Debian Stretch-backports and newer ship with libluajit-5.1-dev (2.1.0~beta3). You could consider enabling `BUNDLED_LUAJIT` by default for Buster and newer.