### PR TITLE
Update dependencies for Debian packaging

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -3,7 +3,7 @@
 export DEPS_DEB="fakeroot make ca-certificates less vim devscripts debhelper \
   dpkg-dev cmake libevent-dev libglib2.0-dev libpcre3-dev \
   libssl-dev libcurl4-openssl-dev libsqlite3-dev perl \
-  libmagic-dev git ragel libicu-dev curl"
+  libmagic-dev git ragel libicu-dev curl libunwind-dev"
 export DISTRIBS_DEB="ubuntu-xenial \
   ubuntu-bionic \
   debian-jessie \

--- a/config.sh
+++ b/config.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 export DEPS_DEB="fakeroot make ca-certificates less vim devscripts debhelper \
-  dpkg-dev cmake libevent-dev libglib2.0-dev libpcre3-dev \
+  dpkg-dev cmake libevent-dev libglib2.0-dev libpcre2-dev libjemalloc-dev \
   libssl-dev libcurl4-openssl-dev libsqlite3-dev perl \
-  libmagic-dev git ragel libicu-dev curl libunwind-dev"
+  libmagic-dev git ragel libicu-dev curl libunwind-dev libsodium-dev"
 export DISTRIBS_DEB="ubuntu-xenial \
   ubuntu-bionic \
   debian-jessie \

--- a/rspamd_build.sh
+++ b/rspamd_build.sh
@@ -455,15 +455,14 @@ if [ $DEPS_STAGE -eq 1 ] ; then
 
 
       case $d in
-        debian-wheezy) REAL_DEPS="$DEPS_DEB liblua5.1-dev libgd2-noxpm-dev libunwind7-dev" ;;
-        debian-jessie) 
+        debian-jessie)
           SPECIFIC_C_COMPILER="clang-8"
           SPECIFIC_CXX_COMPILER="clang++-8"
-          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
+          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP}"
           HYPERSCAN="yes"
           ;;
-        debian-stretch) 
-          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
+        debian-stretch)
+          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP}"
           HYPERSCAN="yes"
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
@@ -471,36 +470,29 @@ if [ $DEPS_STAGE -eq 1 ] ; then
         debian-buster)
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
-          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
+          REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"
           HYPERSCAN="yes"
           ;;
-        debian-sid) 
+        debian-sid)
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
-          REAL_DEPS="$DEPS_DEB dh-systemd build-essential ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
+          REAL_DEPS="$DEPS_DEB build-essential ${LUAJIT_DEP}"
           HYPERSCAN="yes"
           ;;
-        ubuntu-precise) REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP} libgd2-noxpm-dev libunwind8-dev" ;;
-        ubuntu-trusty)
-          SPECIFIC_C_COMPILER="clang-6.0"
-          SPECIFIC_CXX_COMPILER="clang++-6.0"
-          REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP} libgd-dev libopenblas-dev liblapack-dev libunwind8-dev"
-          HYPERSCAN="yes"
-          ;;
-        ubuntu-xenial) 
+        ubuntu-xenial)
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
-          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
+          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP}"
           HYPERSCAN="yes"
           ;;
-        ubuntu-bionic) 
+        ubuntu-bionic)
           SPECIFIC_C_COMPILER="clang-9"
           SPECIFIC_CXX_COMPILER="clang++-9"
-          REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP} libgd-dev libblas-dev liblapack-dev libunwind-dev" 
+          REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"
           HYPERSCAN="yes"
           ;;
         ubuntu-*)
-          REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP} libgd-dev libopenblas-dev liblapack-dev libunwind-dev"
+          REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"
           HYPERSCAN="yes"
           ;;
         *) REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}" HYPERSCAN="yes" ;;
@@ -595,7 +587,6 @@ build_rspamd_deb() {
 
   _id=`git -C ${HOME}/rspamd rev-parse --short HEAD`
   _distname=`echo $d | sed -r -e 's/ubuntu-|debian-//' -e 's/-i386//'`
-  _deps_line=`echo ${REAL_DEPS} | tr ' ' ','`
   if [ -n "${STABLE}" ] ; then
     RULES_SED="${RULES_SED} -e \"s/-DDEBIAN_BUILD=1/-DDEBIAN_BUILD=1 -DCMAKE_C_COMPILER=${SPECIFIC_C_COMPILER} -DCMAKE_CXX_COMPILER=${SPECIFIC_CXX_COMPILER}/\""
   else
@@ -619,7 +610,11 @@ build_rspamd_deb() {
   chroot ${HOME}/$d sh -c "cp rspamd-${RSPAMD_VER}.tar.xz ${DEB_BUILD_PREFIX}/rspamd_${RSPAMD_VER}.orig.tar.xz"
   
   # Build normal
-  chroot ${HOME}/$d sh -c "sed -e \"s/Build-Depends:.*/Build-Depends: ${_deps_line}/\" -e \"s/Maintainer:.*/Maintainer: Vsevolod Stakhov <vsevolod@highsecure.ru>/\" < ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control > /tmp/.tt ; mv /tmp/.tt ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
+  if [[ " ${REAL_DEPS} " == *" dh-systemd "* ]]; then
+    # Fix dependencies for Debian before stretch, Ubuntu before xenial-backports
+    chroot ${HOME}/$d sh -c "sed -e \"s/debhelper (>= 10),/debhelper (>= 9), dh-systemd,/\" -i ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
+  fi
+  chroot ${HOME}/$d sh -c "sed -e \"s/Maintainer:.*/Maintainer: Vsevolod Stakhov <vsevolod@highsecure.ru>/\" < ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control > /tmp/.tt ; mv /tmp/.tt ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
   chroot ${HOME}/$d sh -c "sed -e \"s/-DCMAKE_BUILD_TYPE=ReleaseWithDebInfo/-DCMAKE_BUILD_TYPE=Release/\" < ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/rules > /tmp/.tt ; mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/rules"
   if [ -n "${STABLE}" ] ; then
     chroot ${HOME}/$d sh -c "sed -e \"s/unstable/${_distname}/\" \
@@ -653,8 +648,12 @@ build_rspamd_deb() {
     DEB_BUILD_PREFIX="/asan"
     chroot ${HOME}/$d sh -c "rm -fr rspamd-${RSPAMD_VER} ${DEB_BUILD_PREFIX} ; mkdir ${DEB_BUILD_PREFIX} ; cd ${DEB_BUILD_PREFIX} ; tar xvf /rspamd-${RSPAMD_VER}.tar.xz"
     chroot ${HOME}/$d sh -c "cp rspamd-${RSPAMD_VER}.tar.xz ${DEB_BUILD_PREFIX}/rspamd_${RSPAMD_VER}.orig.tar.xz"
-    
-    chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed -e \"s/Build-Depends:.*/Build-Depends: ${_deps_line}/\" -e \"s/Maintainer:.*/Maintainer: Vsevolod Stakhov <vsevolod@highsecure.ru>/\" < rspamd-${RSPAMD_VER}/debian/control > /tmp/.tt ; mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/control"
+
+    if [[ " ${REAL_DEPS} " == *" dh-systemd "* ]]; then
+      # Fix dependencies for Debian before stretch, Ubuntu before xenial-backports
+      chroot ${HOME}/$d sh -c "sed -e \"s/debhelper (>= 10),/debhelper (>= 9), dh-systemd,/\" -i ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
+    fi
+    chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed -e \"s/Maintainer:.*/Maintainer: Vsevolod Stakhov <vsevolod@highsecure.ru>/\" < rspamd-${RSPAMD_VER}/debian/control > /tmp/.tt ; mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/control"
     chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed -e \"s/-DCMAKE_BUILD_TYPE=ReleaseWithDebInfo/-DCMAKE_BUILD_TYPE=Debug -DSANITIZE=address/\" < rspamd-${RSPAMD_VER}/debian/rules > /tmp/.tt ; mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/rules"
     if [ -n "${STABLE}" ] ; then
       chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed -e \"s/unstable/${_distname}/\" \
@@ -813,14 +812,14 @@ if [ $BUILD_STAGE -eq 1 ] ; then
               -e 's/-DWANT_SYSTEMD_UNITS=ON/-DWANT_SYSTEMD_UNITS=ON -DENABLE_HYPERSCAN=ON -DHYPERSCAN_ROOT_DIR=\/opt\/hyperscan -DENABLE_FANN=OFF/'"
             ;;
           debian-sid)
-            REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP}"
+            REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"
             RULES_SED="-e 's/--with systemd/--with systemd --parallel/' \
               -e 's/-DWANT_SYSTEMD_UNITS=ON/-DWANT_SYSTEMD_UNITS=ON -DENABLE_HYPERSCAN=ON -DHYPERSCAN_ROOT_DIR=\/opt\/hyperscan -DENABLE_FANN=OFF/'"
             #SPECIFIC_C_COMPILER="clang-9"
             #SPECIFIC_CXX_COMPILER="clang++-9"
             ;;
           debian-buster)
-            REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP}"
+            REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"
             RULES_SED="-e 's/--with systemd/--with systemd --parallel/' \
               -e 's/-DWANT_SYSTEMD_UNITS=ON/-DWANT_SYSTEMD_UNITS=ON -DENABLE_HYPERSCAN=ON -DHYPERSCAN_ROOT_DIR=\/opt\/hyperscan -DENABLE_FANN=OFF/'"
             #SPECIFIC_C_COMPILER="clang-9"
@@ -836,16 +835,9 @@ if [ $BUILD_STAGE -eq 1 ] ; then
           ubuntu-bionic)
             #SPECIFIC_C_COMPILER="clang-9"
             #SPECIFIC_CXX_COMPILER="clang++-9"
-            REAL_DEPS="$DEPS_DEB dh-systemd ${LUAJIT_DEP}"
+            REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"
             RULES_SED="-e 's/--with systemd/--with systemd --parallel/' \
               -e 's/-DWANT_SYSTEMD_UNITS=ON/-DWANT_SYSTEMD_UNITS=ON -DENABLE_HYPERSCAN=ON -DHYPERSCAN_ROOT_DIR=\/opt\/hyperscan -DENABLE_FANN=OFF/'"
-            ;;
-          ubuntu-trusty)
-            SPECIFIC_C_COMPILER="clang-6.0"
-            SPECIFIC_CXX_COMPILER="clang++-6.0"
-            REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"
-            RULES_SED="-e 's/--with systemd/--parallel/' \
-              -e 's/-DWANT_SYSTEMD_UNITS=ON/-DWANT_SYSTEMD_UNITS=OFF -DENABLE_HYPERSCAN=ON -DHYPERSCAN_ROOT_DIR=\/opt\/hyperscan -DENABLE_FANN=OFF/'"
             ;;
           ubuntu-*)
             REAL_DEPS="$DEPS_DEB ${LUAJIT_DEP}"

--- a/rspamd_build.sh
+++ b/rspamd_build.sh
@@ -614,6 +614,10 @@ build_rspamd_deb() {
     # Fix dependencies for Debian before stretch, Ubuntu before xenial-backports
     chroot ${HOME}/$d sh -c "sed -e \"s/debhelper (>= 10),/debhelper (>= 9), dh-systemd,/\" -i ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
   fi
+  if [[ " ${REAL_DEPS} " != *" luajit-5.1-dev "* ]]; then
+    # Use bundled luajit package, disable distro package.
+    chroot ${HOME}/$d sh -c "sed -e \"/^ *luajit-5.1-dev/d\" -i ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
+  fi
   chroot ${HOME}/$d sh -c "sed -e \"s/Maintainer:.*/Maintainer: Vsevolod Stakhov <vsevolod@highsecure.ru>/\" < ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control > /tmp/.tt ; mv /tmp/.tt ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
   chroot ${HOME}/$d sh -c "sed -e \"s/-DCMAKE_BUILD_TYPE=ReleaseWithDebInfo/-DCMAKE_BUILD_TYPE=Release/\" < ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/rules > /tmp/.tt ; mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/rules"
   if [ -n "${STABLE}" ] ; then
@@ -652,6 +656,10 @@ build_rspamd_deb() {
     if [[ " ${REAL_DEPS} " == *" dh-systemd "* ]]; then
       # Fix dependencies for Debian before stretch, Ubuntu before xenial-backports
       chroot ${HOME}/$d sh -c "sed -e \"s/debhelper (>= 10),/debhelper (>= 9), dh-systemd,/\" -i ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
+    fi
+    if [[ " ${REAL_DEPS} " != *" luajit-5.1-dev "* ]]; then
+      # Use bundled luajit package, disable distro package.
+      chroot ${HOME}/$d sh -c "sed -e \"/^ *luajit-5.1-dev/d\" -i ${DEB_BUILD_PREFIX}/rspamd-${RSPAMD_VER}/debian/control"
     fi
     chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed -e \"s/Maintainer:.*/Maintainer: Vsevolod Stakhov <vsevolod@highsecure.ru>/\" < rspamd-${RSPAMD_VER}/debian/control > /tmp/.tt ; mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/control"
     chroot ${HOME}/$d sh -c "cd ${DEB_BUILD_PREFIX} ; sed -e \"s/-DCMAKE_BUILD_TYPE=ReleaseWithDebInfo/-DCMAKE_BUILD_TYPE=Debug -DSANITIZE=address/\" < rspamd-${RSPAMD_VER}/debian/rules > /tmp/.tt ; mv /tmp/.tt rspamd-${RSPAMD_VER}/debian/rules"

--- a/rspamd_build.sh
+++ b/rspamd_build.sh
@@ -243,7 +243,8 @@ get_rspamd() {
     fi
   fi
 
-  ( mkdir ${HOME}/rspamd.build ; cd ${HOME}/rspamd.build ; cmake ${HOME}/rspamd ; make dist )
+  mkdir ${HOME}/rspamd.build
+  ( cd ${HOME}/rspamd; ./dist.sh ${HOME}/rspamd.build/rspamd-${RSPAMD_VER}.tar.xz )
   if [ $? -ne 0 ] ; then
     exit 1
   fi


### PR DESCRIPTION
* Remove some unneeded dependencies for rspamd 2.3, add missing ones.
* Properly disable distro luajit if the bundled luajit version is not requested.
* Use hyperscan from distro if available.
* Do not run `cmake ...; make dist`, run `dist.sh` directly to avoid requiring excess dependencies.

This fixes the build since https://github.com/rspamd/rspamd/pull/3227 got merged.
I have successfully tested this for ubuntu-bionic and debian-buster (but not jessie nor sid). Using the base image from https://cdimage.debian.org/cdimage/openstack/current-10/ (10G disk, 6G memory, 7 cores).

The `--bootstrap` option seems not intended for `MAIN_ARCH="x86_64"`, it has to be `amd64` to work for Debian, and for Ubuntu it needs a different mirror. Thefore I manually ran debootstrap before.

```
# curl is only needed for downloading and building hyperscan
# xz-utils is for dist.sh
apt update && apt install -y rsync git debootstrap ubuntu-archive-keyring curl xz-utils
debootstrap --variant=buildd --arch=amd64 buster /root/debian-buster http://httpredir.debian.org/debian/
debootstrap --variant=buildd --arch=amd64 bionic /root/ubuntu-bionic http://uk.archive.ubuntu.com/ubuntu/
./rspamd_build.sh --no-rpm --deps --build --jobs=8 --build
```

When I try to test this for ubuntu-xenial (or debian-stretch), it fails because the script did not install clang-9. I am tempted to remove this, you might have added this for ASAN support, is that correct? Can I remove it since GCC 4.8 and up support it? Ubuntu Xenial ships with GCC 5.3.1 by default.
(And of course, boost.tar.gz is missing, so the fresh bootstrap fails too when trying to build hyperscan.)